### PR TITLE
Fix logging

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -198,15 +198,15 @@ export class Main {
             let str = message.args[4 + 1 + (2*i)];
             let lines = str.split(/\r?\n/);
             if (!str){
-                toShow += " |";
+                toShow = " |";
             }
             else if (i === (count - 1)){
-                toShow += " └─ ";
+                toShow = " └─ ";
             }
             else{
-                toShow += " ├─ ";
+                toShow = " ├─ ";
             }
-            this.logOutput.appendLine(toShow);
+            this.logOutput.append(toShow);
 
             lines.forEach((line: string) => {
                 this.logOutput.appendLine(line);


### PR DESCRIPTION
Logging output doesn't look quite right, with the following simple example:
```ruby
use_real_time
play 60
puts "hi"
sample :bd_ada
```
The log output currenly looks like:
```
Starting run 11
{run: 11, time: 0.0, thread: ""}
 ├─ 
synth :beep, {note: 60.0}
 ├─  ├─ 
"hi"
 ├─  ├─  └─ 
sample "/Applications/Sonic Pi.app/Contents/Resources/etc/samples",
           "bd_ada.flac"
Completed run 11
All runs completed
Pausing SuperCollider Audio Server
```
With this change, we get:
```
Starting run 9
{run: 9, time: 0.0, thread: ""}
 ├─ synth :beep, {note: 60.0}
 ├─ "hi"
 └─ sample "/Applications/Sonic Pi.app/Contents/Resources/etc/samples",
           "bd_ada.flac"
Completed run 9
All runs completed
Pausing SuperCollider Audio Server
```