### PR TITLE
Take Ruby interpreter path from configuration

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -101,6 +101,10 @@ export class Main {
         if (vscode.workspace.getConfiguration('sonicpieditor').sonicPiRootDirectory){
             this.rootPath = vscode.workspace.getConfiguration('sonicpieditor').sonicPiRootDirectory;
         }
+        
+        if (vscode.workspace.getConfiguration('ruby.interpreter').commandPath){
+            this.rubyPath = vscode.workspace.getConfiguration('ruby.interpreter').commandPath;
+        }
 
         console.log('Using Sonic Pi root directory: ' + this.rootPath);
         console.log('Using ruby: ' + this.rubyPath);


### PR DESCRIPTION
I have Sonic PI installed from source, and `app/server/native/ruby` symlinked here
It somehow does not working for me. Once I switch to global Ruby it again working