### PR TITLE
accepting multi-byte comment in code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1827,6 +1827,11 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"utf8": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+			"integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+		},
 		"uuid": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
 				"sonicpieditor.sonicPiRootDirectory": {
 					"type": "string",
 					"description": "Set Sonic Pi installation directory.\nOnly use this if the default does not work for you."
-
 				},
 				"sonicpieditor.launchSonicPiServerAutomatically": {
 					"type": "string",
@@ -167,6 +166,7 @@
 	},
 	"dependencies": {
 		"osc-js": "2.1.0",
+		"utf8": "^3.0.0",
 		"uuid": "8.1.0"
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ const os = require('os');
 const child_process = require('child_process');
 import { OscSender } from './oscsender';
 const OSC = require('osc-js');
+const utf8 = require('utf8');
 const { v4: uuidv4 } = require('uuid');
 
 
@@ -456,6 +457,7 @@ export class Main {
         if (vscode.workspace.getConfiguration('sonicpieditor').safeMode){
             code = "use_arg_checks true #__nosave__ set by Qt GUI user preferences.\n" + code ;
         }
+        code = utf8.encode(code);
         this.clearErrorHighlight();
         let message = new OSC.Message('/run-code', this.guiUuid, code);
         this.sendOsc(message);


### PR DESCRIPTION
In the case code's comment include multibyte charset, running code get failed.
Also, in sonic-pi's server execute force_encoding when receiving code.
https://github.com/sonic-pi-net/sonic-pi/blob/main/app/server/ruby/bin/sonic-pi-server.rb#L338

So, I think code should have been converted to utf-8 before sending to sonic-pi.
